### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "torch",
     "botorch>=0.15",
     "lume-base",
-	"pvua@git+ssh://git@github.com/slac-epics/pvua.git",
+    "pvua @ git+https://github.com/slac-epics/pvua"
 ]
 dynamic = ["version"]
 [tool.setuptools_scm]


### PR DESCRIPTION
This pull request updates the dependency specification for `pvua` in the `pyproject.toml` file, switching from an SSH-based Git URL to an HTTPS-based URL. 

Since `pvua` is now public, this change makes installation easier for users and CI pipelines who may not have SSH access configured.
