### PR TITLE
REF: adjust run-loop and queue system to support put-completion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         working-directory: ${{ runner.temp }}
         run: |
-          uv run --project ${{ github.workspace }} --no-sync pytest --pyargs lume.tests
+          uv run --project ${{ github.workspace }} --no-sync pytest --pyargs lume_pva.tests

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -30,6 +30,28 @@ VALID_MODEL_MODES = ["continuous", "snapshot"]
 DEFAULT_MODEL_MODE = "continuous"
 DEFAULT_PV_MODE = "rw"
 
+
+class RunnerVariable(TypedDict):
+    """
+    Attributes
+    ----------
+    name : str
+        Name of the input or output. Must match one of the model's supported variables.
+    pv : str
+        Name of the PV to serve or consume. If not provided, it will be defaulted to 'name'
+    mode : str
+        Operation mode of the PV. May be one of:
+        - 'ro': Read-only PV served by this server
+        - 'rw': Read-write PV served by this server. Errors if Variable.read_only
+        - 'remote': Remote PV living on some other remote machine.
+        Default is 'rw'
+    """
+
+    name: str
+    pv: str
+    mode: str
+
+
 class RunnerConfig(TypedDict):
     """
     Attributes
@@ -47,26 +69,6 @@ class RunnerConfig(TypedDict):
     protocol : list[str]
         List of supported protocols
     """
-
-    class RunnerVariable(TypedDict):
-        """
-        Attributes
-        ----------
-        name : str
-            Name of the input or output. Must match one of the model's supported variables.
-        pv : str
-            Name of the PV to serve or consume. If not provided, it will be defaulted to 'name'
-        mode : str
-            Operation mode of the PV. May be one of:
-            - 'ro': Read-only PV served by this server
-            - 'rw': Read-write PV served by this server. Errors if Variable.read_only
-            - 'remote': Remote PV living on some other remote machine.
-            Default is 'rw'
-        """
-
-        name: str
-        pv: str
-        mode: str
 
     remote_model_mode: str
     prefix: str

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -7,7 +7,7 @@ from p4p.nt import NTScalar
 from p4p import Value, Type
 from typing import Any, Dict, TypedDict
 from collections.abc import Callable
-from queue import Queue
+from queue import Empty, Queue
 from enum import IntEnum
 from lume_pva.variables import VariableHandler, find_variable_handler
 import time
@@ -95,7 +95,7 @@ class Runner:
         model: LUMEModel
         variable: Variable
 
-        def __init__(self, variable: Variable, runner, read_only: bool):
+        def __init__(self, variable: Variable, runner: "Runner", read_only: bool):
             self.model = runner.model
             self.variable = variable
             self.runner = runner
@@ -106,18 +106,19 @@ class Runner:
                 op.done(error="Read only PV")
             else:
                 # Update PVs in simulator
-                self.runner.queue.put(
-                    {self.variable.name: {"value": op.value(), "ts": time.monotonic()}}
+                self.runner._enqueue(
+                    {self.variable.name: {"value": op.value(), "ts": time.monotonic()}},
+                    done=lambda error: op.done(error=error)
                 )
                 pv.post(op.value())
-                op.done()
+                LOG.debug(f"Setting PVA: {self.variable.name} -> {op.value()}")
 
         def rpc(self, op: ServerOperation):
             op.done()
 
     class CaDriver(pcaspy.Driver):
         """ChannelAccess driver handling operations on behalf of the Runner class"""
-        def __init__(self, runner):
+        def __init__(self, runner: "Runner"):
             super().__init__()
             self.runner = runner
 
@@ -147,9 +148,14 @@ class Runner:
                 nv = desc["enums"][value]
 
             # Insert into update queue
-            self.runner.queue.put({vn: {"value": nv, "ts": time.monotonic()}})
+            def _complete_put():
+                self.setParam(reason, value)
+                self.callbackPV(reason)
 
-            self.setParam(reason, value)
+            self.runner._enqueue(
+                {vn: {"value": nv, "ts": time.monotonic()}},
+                done=lambda error: _complete_put()
+            )
             return True
 
     def __init__(
@@ -291,7 +297,7 @@ class Runner:
             self.ca_thread.start()
 
         # Kick off an initial update to propagate any defaults the model may have set
-        self.queue.put({})
+        self._enqueue({})
 
     def _run_pcaspy(self):
         """Run pcaspy forever"""
@@ -347,6 +353,23 @@ class Runner:
             }
         return config
 
+    def _enqueue(self, values: Dict[str, Any], done: Callable[[str | None], None] | None = None) -> None:
+        """
+        Enqueue a batch of PV updates to be applied to the model.
+
+        Parameters
+        ----------
+        values : Dict[str, Any]
+            Mapping of variable name -> {"value": ..., "ts": ...}
+        done : Callable[[str | None], None] | None
+            Optional completion callback. Invoked once the simulation that
+            consumes these values has finished (or failed). Receives an error
+            string on failure, or None on success. Used to defer signalling
+            put-completion to clients until results are actually available.
+        """
+        self.queue.put({"values": values, "done": [done] if done is not None else []})
+
+
     def _add_pv(
         self, pv: str, var: Variable, ro: bool, prefix: str, handler: VariableHandler
     ) -> None:
@@ -393,6 +416,8 @@ class Runner:
             spec = handler.ca_pvspec(var)
 
             self.pvdb[f'{prefix}{pv}'] = spec
+            self.pvdb[f'{prefix}{pv}'].update({"asyn": True})
+            # enable async for put-completion
             self.ca_pvs[var.name] = pv
 
     def _add_client(self, pv: str, var: Variable, monitor: bool) -> bool:
@@ -476,11 +501,11 @@ class Runner:
                 "value": self.pvua_context.get(pv),
                 "ts": time.monotonic(),
             }
-        self.queue.put(new_values)
+        self._enqueue(new_values)
 
     def _monitor_callback(self, pvname, value, **kwargs):
         """Callback from p4p monitor updates"""
-        self.queue.put({self.pv_to_var[pvname]: {"value": value, "ts": time.monotonic()}})
+        self._enqueue({self.pv_to_var[pvname]: {"value": value, "ts": time.monotonic()}})
 
     def _generate_value(
         self, pv: str, value: Any | None, ts: float | None = None
@@ -519,19 +544,24 @@ class Runner:
         """
         while True:
             # Wait for new data to come in
-            up = self.queue.get()
+            item = self.queue.get()
+
+            value_data: dict = item["values"]
+            done_callbacks: list = item["done"]
 
             # Wait for a time window of 'update_rate' seconds to pass before continuing
             until = time.monotonic() + self.update_rate
             while time.monotonic() < until:
                 try:
-                    up.update(self.queue.get_nowait())
-                except:
+                    next_update = self.queue.get_nowait()
+                    value_data.update(next_update["values"])
+                    done_callbacks.extend(next_update["done"])
+                except Empty:
                     pass
 
             new_values = {}
             latest_ts = 0.0
-            for k, g in up.items():
+            for k, g in value_data.items():
                 v = g["value"]
                 ts = g["ts"]
 
@@ -552,52 +582,66 @@ class Runner:
                 latest_ts = time.monotonic()
 
             # Set and simulate
-            set_start = time.perf_counter()
-            LOG.debug(f"Setting model with new values: {new_values}")
-            self.model.set(new_values)
-            LOG.debug(
-                f"Model set() took {(time.perf_counter() - set_start) * 1000.0:.3f} ms"
-            )
+            sim_error = None
+            try:
+                set_start = time.perf_counter()
+                LOG.debug(f"Setting model with new values: {new_values}")
+                self.model.set(new_values)
+                LOG.debug(
+                    f"Model set() took {(time.perf_counter() - set_start) * 1000.0:.3f} ms"
+                )
 
-            # Get new simulated values
-            get_start = time.perf_counter()
-            out_values = self.model.get(self.model.supported_variables)
-            LOG.debug(
-                f"Model get() took {(time.perf_counter() - get_start) * 1000.0:.3f} ms"
-            )
+                # Get new simulated values
+                get_start = time.perf_counter()
+                out_values = self.model.get(self.model.supported_variables)
+                LOG.debug(
+                    f"Model get() took {(time.perf_counter() - get_start) * 1000.0:.3f} ms"
+                )
 
-            # Update output PVs with new values
-            pv_update_start = time.perf_counter()
-            LOG.debug(f"writing {len(out_values)} PVs")
-            for k, v in out_values.items():
-                # Avoid attempting to post to client monitors
-                if k in self.subs:
-                    continue
+                # Update output PVs with new values
+                pv_update_start = time.perf_counter()
+                LOG.debug(f"writing {len(out_values)} PVs")
+                for k, v in out_values.items():
+                    # Avoid attempting to post to client monitors
+                    if k in self.subs:
+                        continue
 
-                # Update PVA component
-                pv = self.pvs.get(k)
-                if pv is not None:
+                    # Update PVA component
+                    pv = self.pvs.get(k)
+                    if pv is not None:
+                        try:
+                            pv.post(self._generate_value(k, v, latest_ts))
+                        except Exception as e:
+                            LOG.error(f"Error posting value for {k}: {e}")
+
+                    # Update CA component
+                    capv = self.ca_pvs.get(k)
+                    if capv is not None and self.ca_driver is not None:
+                        # pcaspy can only understand native python types, not necessarily what the model gives us.
+                        nv = self.pv_handlers[k].value_to_native(
+                            self.model.supported_variables[k], v
+                        )
+
+                        self.ca_driver.setParam(capv, nv, pcaspy.cas.epicsTimeStamp.fromPosixTimeStamp(latest_ts))
+
+                if self.ca_driver is not None:
+                    self.ca_driver.updatePVs()
+
+                LOG.debug(
+                    f"PV update loop took {(time.perf_counter() - pv_update_start) * 1000.0:.3f} ms"
+                )
+            except Exception as exc:
+                sim_error = str(exc)
+                LOG.error(f"Simulation Cycle Failed: ({sim_error})")
+                raise
+            finally:
+                # With simulation compoleted, signal put completion to any waitihng clients
+                for cb in done_callbacks:
                     try:
-                        pv.post(self._generate_value(k, v, latest_ts))
-                    except Exception as e:
-                        LOG.error(f"Error posting value for {k}: {e}")
+                        cb(sim_error)
+                    except Exception as excp:
+                        LOG.error(f"Error signalling put-completion: {excp}")
 
-                # Update CA component
-                capv = self.ca_pvs.get(k)
-                if capv is not None and self.ca_driver is not None:
-                    # pcaspy can only understand native python types, not necessarily what the model gives us.
-                    nv = self.pv_handlers[k].value_to_native(
-                        self.model.supported_variables[k], v
-                    )
-
-                    self.ca_driver.setParam(capv, nv, pcaspy.cas.epicsTimeStamp.fromPosixTimeStamp(latest_ts))
-
-            if self.ca_driver is not None:
-                self.ca_driver.updatePVs()
-
-            LOG.debug(
-                f"PV update loop took {(time.perf_counter() - pv_update_start) * 1000.0:.3f} ms"
-            )
 
     def run(self):
         """

--- a/lume_pva/tests/test_put_completion.py
+++ b/lume_pva/tests/test_put_completion.py
@@ -1,0 +1,247 @@
+"""Put-completion tests for :class:`lume_pva.runner.Runner`.
+
+Relies on multiprocessing.Event gates to track the exact state of the model
+in the Runner.
+
+Rough flow:
+1. Issue the put on a background thread.
+2. Wait until the simulation has entered ``_set`` (so the value was delivered
+   and dequeued by the runner).
+3. While the gate is still closed, assert the put has **not** returned -- this
+   is the property that breaks if put-completion is removed (the client would
+   be signalled immediately).
+4. Open the gate, let the simulation finish, and assert the put now returns.
+5. Confirm the output PV already holds the freshly computed value, proving the
+   put waited for the whole cycle
+
+Two EPICS providers are exercised:
+- PVA via ``p4p``
+- CA via ``pyepics``
+
+Runners are started up in independent subprocesses to ensure each test gets a
+fresh Runner.
+"""
+
+from dataclasses import dataclass
+import multiprocessing
+from multiprocessing.synchronize import Event as mpEvent
+import os
+import threading
+from typing import Callable, Generator
+
+import pytest
+
+# Keep all EPICS traffic on the loopback interface. Must be set before p4p,
+# pyepics, or the pcaspy server (created in Runner.__init__) initialise.
+os.environ.setdefault("EPICS_CA_ADDR_LIST", "127.0.0.1")
+os.environ.setdefault("EPICS_CA_AUTO_ADDR_LIST", "NO")
+os.environ.setdefault("EPICS_PVA_ADDR_LIST", "127.0.0.1")
+os.environ.setdefault("EPICS_PVA_AUTO_ADDR_LIST", "NO")
+
+import epics  # noqa: E402  (import after env is configured)
+from lume.model import LUMEModel  # noqa: E402
+from lume.variables import ScalarVariable  # noqa: E402
+from p4p.client.thread import Context  # noqa: E402
+
+from lume_pva.runner import Runner  # noqa: E402
+
+# Generous upper bound for any single operation to complete.
+OP_TIMEOUT = 10.0
+# Window during which a blocked put is observed to *not* complete. The gate is
+# genuinely closed for this whole window, so the simulation cannot finish and a
+# correct put cannot return -- this is a lower bound, not a race.
+BLOCK_WINDOW = 0.5
+
+
+# pin process start method for consistency
+_MP = multiprocessing.get_context("spawn")
+
+
+class GatedModel(LUMEModel):
+    """
+    A model whose simulation blocks until the test opens the gate.
+
+    ``sum_output`` is computed as ``2 * input_a`` so that a completed put leaves
+    an unambiguous, checkable value on the output PV.
+    """
+
+    def __init__(
+        self,
+        release: mpEvent,
+        entered: mpEvent,
+        completed: mpEvent,
+    ) -> None:
+        self._state = {"input_a": 0.0, "sum_output": 0.0}
+        self._vars = {
+            "input_a": ScalarVariable(
+                name="input_a",
+                default_value=0.0,
+                value_range=(-1e6, 1e6),
+                read_only=False,
+            ),
+            "sum_output": ScalarVariable(
+                name="sum_output",
+                default_value=0.0,
+                read_only=True,
+            ),
+        }
+        # Set => _set proceeds. Cleared => _set blocks.
+        self.release = release
+        # Set when the simulation enters _set (value delivered + dequeued).
+        self.entered = entered
+        # Set when the simulation finishes a cycle.
+        self.completed = completed
+
+    @property
+    def supported_variables(self) -> dict[str, ScalarVariable]:
+        return self._vars
+
+    def _get(self, names: list[str]) -> dict[str, float]:
+        return {name: self._state[name] for name in names}
+
+    def _set(self, values: dict[str, float]) -> None:
+        self.entered.set()
+        if not self.release.wait(timeout=OP_TIMEOUT):
+            raise TimeoutError("simulation gate was never opened")
+        self._state.update(values)
+        self._state["sum_output"] = self._state["input_a"] * 2.0
+        self.completed.set()
+
+    def reset(self) -> None:
+        # Implemented to appease type-checker
+        self._state = {"input_a": 0.0, "sum_output": 0.0}
+
+
+def _serve(release: mpEvent, entered: mpEvent, completed: mpEvent, ready: mpEvent) -> None:
+    """Child-process entry point: serve a gated model over CA and PVA.
+
+    Must be importable at module top level so the ``spawn`` start method can
+    locate it. Blocks forever once ready; the parent terminates the process.
+    """
+    model = GatedModel(release, entered, completed)
+    config = Runner.generate_config(model)
+    # No batching delay -- the cycle is driven purely by the gate.
+    config["update_rate"] = 0.0
+
+    # Let the implicit startup cycle (Runner.__init__ enqueues an empty update)
+    # pass freely before the parent arms the gate.
+    release.set()
+
+    runner = Runner(model=model, config=config)
+    threading.Thread(target=runner._run, daemon=True).start()
+
+    if not completed.wait(timeout=OP_TIMEOUT):
+        raise RuntimeError("startup cycle never ran in child")
+
+    # Server startup cycle complete
+    ready.set()
+    # block until terminated
+    threading.Event().wait()
+
+
+@dataclass
+class RunnerHandle:
+    release: mpEvent
+    entered: mpEvent
+    completed: mpEvent
+
+
+@pytest.fixture(scope="function")
+def harness() -> Generator[RunnerHandle, None, None]:
+    """Run a Runner in a child process and yield the shared gate + a PVA client.
+
+    Function-scoped: each test gets a pristine child, and terminating it on
+    teardown reclaims the EPICS ports so tests stay independent.
+    """
+    release = _MP.Event()
+    entered = _MP.Event()
+    completed = _MP.Event()
+    ready = _MP.Event()
+
+    proc = _MP.Process(
+        target=_serve,
+        args=(release, entered, completed, ready),
+        daemon=True,
+    )
+    proc.start()
+    assert ready.wait(timeout=OP_TIMEOUT), "child Runner never became ready"
+
+    handle = RunnerHandle(
+        release=release,
+        entered=entered,
+        completed=completed,
+    )
+    try:
+        yield handle
+    finally:
+        release.set()
+        proc.terminate()
+        proc.join(timeout=OP_TIMEOUT)
+        # Drop pyepics channels bound to the now-dead server so the next test
+        # connects fresh rather than to a stale, disconnected channel.
+        epics.ca.clear_cache()
+
+
+def clear_harness(harness: RunnerHandle) -> None:
+    """Close gates so the next simulation cycle blocks until released."""
+    harness.entered.clear()
+    harness.completed.clear()
+    harness.release.clear()
+
+
+def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) -> None:
+    """Run ``putter`` on a thread and assert it blocks until the sim completes.
+
+    ``putter`` must perform a blocking, completion-aware put (PVA put, or
+    ``caput(wait=True)``).
+    """
+    clear_harness(harness)
+
+    put_returned = threading.Event()
+    errors: list[BaseException] = []
+
+    def _do_put() -> None:
+        try:
+            putter()
+        except BaseException as exc:  # noqa: BLE001 - surfaced to the test
+            errors.append(exc)
+        finally:
+            put_returned.set()
+
+    thread = threading.Thread(target=_do_put, daemon=True)
+    thread.start()
+
+    # The value reached the runner and the simulation is now running...
+    assert harness.entered.wait(timeout=OP_TIMEOUT), "simulation never started"
+
+    # ...so a completion-aware put must still be blocked. If this fires, the
+    # client was signalled before the simulation finished (put-completion bug).
+    assert not put_returned.wait(timeout=BLOCK_WINDOW), (
+        "put reported completion before the simulation finished"
+    )
+    assert thread.is_alive()
+
+    # Let the simulation finish; the put must now complete.
+    harness.release.set()
+    assert put_returned.wait(timeout=OP_TIMEOUT), "put never completed"
+    thread.join(timeout=OP_TIMEOUT)
+    assert not errors, f"put raised: {errors[0]!r}"
+
+
+def test_pva_put_waits_for_simulation(harness: RunnerHandle) -> None:
+    with Context("pva") as ctx:
+        _assert_put_completion(
+            harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT)
+        )
+
+        assert harness.completed.is_set()
+        assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
+
+
+def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
+    _assert_put_completion(
+        harness, lambda: epics.caput("input_a", 7.0, wait=True, timeout=OP_TIMEOUT)
+    )
+
+    assert harness.completed.is_set()
+    assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(14.0)

--- a/lume_pva/tests/test_put_completion.py
+++ b/lume_pva/tests/test_put_completion.py
@@ -52,7 +52,6 @@ OP_TIMEOUT = 10.0
 # correct put cannot return -- this is a lower bound, not a race.
 BLOCK_WINDOW = 0.5
 
-
 # pin process start method for consistency
 _MP = multiprocessing.get_context("spawn")
 
@@ -224,6 +223,7 @@ def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) ->
     # Let the simulation finish; the put must now complete.
     harness.release.set()
     assert put_returned.wait(timeout=OP_TIMEOUT), "put never completed"
+    # Finish the put action.  Thread will fail to join if put does not complete
     thread.join(timeout=OP_TIMEOUT)
     assert not errors, f"put raised: {errors[0]!r}"
 
@@ -231,7 +231,7 @@ def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) ->
 def test_pva_put_waits_for_simulation(harness: RunnerHandle) -> None:
     with Context("pva") as ctx:
         _assert_put_completion(
-            harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT)
+            harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True)
         )
 
         assert harness.completed.is_set()
@@ -239,8 +239,10 @@ def test_pva_put_waits_for_simulation(harness: RunnerHandle) -> None:
 
 
 def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
+    # caput timeout needs to essentially run forever, to `_assert_put_completion` to check
+    # if the thread has completed.
     _assert_put_completion(
-        harness, lambda: epics.caput("input_a", 7.0, wait=True, timeout=OP_TIMEOUT)
+        harness, lambda: epics.caput("input_a", 7.0, wait=True, timeout=10*OP_TIMEOUT)
     )
 
     assert harness.completed.is_set()

--- a/lume_pva/tests/test_variables.py
+++ b/lume_pva/tests/test_variables.py
@@ -23,7 +23,6 @@ from lume.variables import (
 from lume_torch.variables import TorchNDVariable, TorchScalarVariable
 from p4p import Type
 
-from caproto import ChannelType
 from lume_pva.epics import epicsAlarmSeverity, epicsAlarmStatus
 from lume_pva.variables import (
     EnumVariableHandler,
@@ -195,7 +194,7 @@ def test_valid_p4p_type(variable: Variable) -> None:
             {"limitLow": 0.0, "limitHigh": 10.0, "minStep": 0.0},
             {
                 "limitLow": 0.0,
-                "limitHigh": 0.0,
+                "limitHigh": 10.0,
                 "description": "",
                 "format": "",
                 "units": "mm",
@@ -514,20 +513,28 @@ def test_raise_packing_invalid_value(
     [
         pytest.param(
             StrVariable(name="s"),
-            {"record": "waveform", "max_length": 1024},
+            {"type": "char", "count": 1024},
             id="string_waveform",
         ),
         pytest.param(BoolVariable(name="b"), {}, id="bool_no_extras"),
-        pytest.param(ScalarVariable(name="x"), {}, id="scalar_no_extras"),
+        pytest.param(
+            ScalarVariable(name="x"),
+            {'unit': None, 'type': 'float', 'lolim': 0, 'hilim': 0, 'lolo': 0, 'hihi': 0},
+            id="scalar_no_extras"),
         pytest.param(TorchScalarVariable(name="x"), {}, id="tscalar_no_extras"),
-        pytest.param(TorchNDVariable(name="x", shape=(2, 3)), {}, id="tnd"),
-        pytest.param(NDVariable(name="x", shape=(2, 3)), {}, id="nd_no_extras"),
+        pytest.param(
+            TorchNDVariable(name="x", shape=(2, 3)),
+            {'count': 6, 'type': 'float'},
+            id="tnd"),
+        pytest.param(
+            NDVariable(name="x", shape=(2, 3)),
+            {'count': 6, 'type': 'float'},
+            id="nd_no_extras"),
         pytest.param(
             EnumVariable(name="e", options=["A", "B"]),
             {
-                "record": "mbbi",
-                "dtype": ChannelType.ENUM,
-                "cls_kwargs": {"enum_strings": ["A", "B"]},
+                "type": "enum",
+                "enums": ["A", "B"],
             },
             id="enum_mbbi",
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ torch = [
 ]
 dev = [
     "pre-commit",
-    "pytest"
+    "p4p",
+    "pyepics",
+    "pytest",
 ]
 docs = [
     "mkdocs",


### PR DESCRIPTION
## Description
- Adds put-completion in both CA and PVA contexts
- Fixes GHA to actually run lume-pva tests, not lume-base tests (I'm sorry, copy pasta error)
- adds tests 

## Context
I don't want to add sleeps every time I scan a PV, and put-completion is an EPICS native way of resolving this issue.  

in pyepics (CA):
```python
write_pv.put(pt, timeout=timeout, wait=True)
```

in p4p (PVA)
```python
ctxt.put(write_pv_name, pt, timeout=timeout, wait=True)
```

The tests might seem overkill, but I wanted to make sure the runner
- doesn't put-complete too early
- doesn't fail to put-complete