### PR TITLE
ENH: add a value cache to revert to when simulation fails

### DIFF
--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -199,6 +199,9 @@ class Runner:
         self.ca_server: pcaspy.SimpleServer | None = None
         self.ca_driver: Runner.CaDriver | None = None
 
+        # Cache for previous state, value per name
+        self._cached_state: dict[str, Any] = {}
+
         # Generate default config
         if config is None:
             config = self.generate_config(model, prefix)
@@ -575,6 +578,12 @@ class Runner:
             if latest_ts <= 0:
                 latest_ts = time.monotonic()
 
+            # Stash previous state
+            settable_var_names = [
+                key for key, var in self.model.supported_variables.items() if not var.read_only
+            ]
+            self._set_cached_state(self.model.get(settable_var_names))
+
             # Set and simulate
             sim_error = None
             try:
@@ -626,8 +635,8 @@ class Runner:
                 )
             except Exception as exc:
                 sim_error = str(exc)
-                LOG.error(f"Simulation Cycle Failed: ({sim_error})")
-                raise
+                LOG.error(f"Simulation Cycle Failed: ({sim_error}), resetting to cached value")
+                self._reset_to_cached_state()
             finally:
                 # With simulation compoleted, signal put completion to any waitihng clients
                 for cb in done_callbacks:
@@ -647,3 +656,13 @@ class Runner:
             return
         except Exception as e:
             raise e
+
+    def _reset_to_cached_state(self) -> None:
+        """Apply cached values to the model"""
+        LOG.info(f"Resetting model with new values: {self._cached_state}")
+        self.model.set(self._cached_state)
+
+    def _set_cached_state(self, state: dict[str, Any]) -> None:
+        """Save `state` to the cache"""
+        LOG.debug(f"Caching model state: {state}")
+        self._cached_state = state

--- a/lume_pva/tests/test_runner_epics.py
+++ b/lume_pva/tests/test_runner_epics.py
@@ -1,18 +1,21 @@
-"""Put-completion tests for :class:`lume_pva.runner.Runner`.
+"""
+End-to-end tests for :class:`lume_pva.runner.Runner`.
+Runner interactions here should be performed using EPICS
 
-Relies on multiprocessing.Event gates to track the exact state of the model
+Put completion test details:
+
+- Relies on multiprocessing.Event gates to track the exact state of the model
 in the Runner.
-
-Rough flow:
-1. Issue the put on a background thread.
-2. Wait until the simulation has entered ``_set`` (so the value was delivered
-   and dequeued by the runner).
-3. While the gate is still closed, assert the put has **not** returned -- this
-   is the property that breaks if put-completion is removed (the client would
-   be signalled immediately).
-4. Open the gate, let the simulation finish, and assert the put now returns.
-5. Confirm the output PV already holds the freshly computed value, proving the
-   put waited for the whole cycle
+- Rough flow:
+    1. Issue the put on a background thread.
+    2. Wait until the simulation has entered ``_set`` (so the value was delivered
+    and dequeued by the runner).
+    3. While the gate is still closed, assert the put has **not** returned -- this
+    is the property that breaks if put-completion is removed (the client would
+    be signalled immediately).
+    4. Open the gate, let the simulation finish, and assert the put now returns.
+    5. Confirm the output PV already holds the freshly computed value, proving the
+    put waited for the whole cycle
 
 Two EPICS providers are exercised:
 - PVA via ``p4p``
@@ -28,8 +31,11 @@ import threading
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event as mpEvent
+from typing import Any
 
 import pytest
+from lume.exceptions import ReadOnlyError
+from lume.variables.variable import ConfigEnum, Variable
 
 # Keep all EPICS traffic on the loopback interface. Must be set before p4p,
 # pyepics, or the pcaspy server (created in Runner.__init__) initialise.
@@ -98,6 +104,27 @@ class GatedModel(LUMEModel):
     def _get(self, names: list[str]) -> dict[str, float]:
         return {name: self._state[name] for name in names}
 
+    def set(self, values: dict[str, Any]) -> None:
+        # vendor LUMEModel.set, but error if validation fails
+        # Validate input values
+        for name in values.keys():
+            if name not in self.supported_variables:
+                raise ValueError(f"Variable '{name}' is not supported by the model.")
+            else:
+                variable = self.supported_variables[name]
+                if not isinstance(variable, Variable):
+                    raise ValueError(f"Variable '{name}' is not a valid Variable instance.")
+
+                if variable.read_only:
+                    raise ReadOnlyError(f"Variable '{name}' is read-only. Cannot be set.")
+                try:
+                    variable.validate_value(values[name], config=ConfigEnum.ERROR)
+                except (ValueError, TypeError) as exc:
+                    raise type(exc)(f"Validation failed for variable '{name}': {exc}") from exc
+
+        # Set the control parameters of the simulator
+        self._set(values)
+
     def _set(self, values: dict[str, float]) -> None:
         self.entered.set()
         if not self.release.wait(timeout=OP_TIMEOUT):
@@ -134,6 +161,8 @@ def _serve(release: mpEvent, entered: mpEvent, completed: mpEvent, ready: mpEven
 
     # Server startup cycle complete
     ready.set()
+    # Mutate state directly for cache testing (thread safety be damned)
+    model._state = {"input_a": 1.0, "sum_output": -20.0}
     # block until terminated
     threading.Event().wait()
 
@@ -147,10 +176,14 @@ class RunnerHandle:
 
 @pytest.fixture(scope="function")
 def harness() -> Generator[RunnerHandle, None, None]:
-    """Run a Runner in a child process and yield the shared gate + a PVA client.
+    """
+    Run a Runner in a child process and yield the shared gate + a PVA client.
 
-    Function-scoped: each test gets a pristine child, and terminating it on
-    teardown reclaims the EPICS ports so tests stay independent.
+    Each test gets a pristine child, and teardown reclaims the EPICS ports so
+    tests stay independent.
+
+    The returned harness provides `multiprocessing.Event` for inspecting the
+    state of the model internals
     """
     release = _MP.Event()
     entered = _MP.Event()
@@ -247,3 +280,36 @@ def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
 
     assert harness.completed.is_set()
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(14.0)
+
+
+def test_standard_sim(harness: RunnerHandle):
+    # attempt set out of bounds, no need to wait
+    epics.caput("input_a", 10.0)
+
+    # assert model set has completed
+    assert harness.completed.is_set()
+    assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(20.0)
+    assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
+
+
+def test_failed_sim(harness: RunnerHandle):
+    assert harness.completed.is_set()
+    # Assert initial state
+    assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(0.0)
+    assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(0.0)
+
+    # Reasonable input
+    epics.caput("input_a", 4.2, wait=True)
+
+    # Verify record has processed
+    assert harness.completed.is_set()
+    assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
+    assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)
+
+    # attempt set out of bounds
+    epics.caput("input_a", 7.0e6, wait=True)
+
+    # reverting to previous (cached) value, runner is still operational
+    assert harness.completed.is_set()
+    assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
+    assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)


### PR DESCRIPTION
## Description
- Caches the writable values of the model before running a simulation, and revert to them if the simulation fails
- Renames test_put_complete -> test_runner_epics to better describe expanded test cases


## Context
We want to not crash the whole epics server when a put causes the simulation to fail.  The exact way this signals is up for debate.  Right now this is essentially a silent rejection of the requested put.  Perhaps we want a separate PV that holds the last simulation status?  Maybe we want to be louder with log statements?  

Opinions / thoughts welcome