### PR TITLE
implement RESET pv, add snapshot to ca protocall

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ which protocol to use. `pvua` prefers the more modern protocol (PVA), if availab
 When configured in snapshot mode, the `Runner` will only fetch values from remote PVs when a snapshot is triggered by a write to
 `{prefix}SNAPSHOT`.
 
+### Control PVs
+
+The runner always exposes a small set of control PVs:
+* `{prefix}SNAPSHOT`: triggers a snapshot pull for remote inputs in snapshot mode.
+* `{prefix}RESET`: any write requests `model.reset()` and publishes the reset state to output PVs.
+
+Control PVs are served over PVA, and are also available over CA when `protocol` includes `"ca"`.
+
 `prefix` is passed to the constructor of the `Runner` class and defines a prefix to prepend to the start of PV names.
 
 ### Configuration

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -501,38 +501,46 @@ class Runner:
 
     def _create_control_pvs(self):
         """Create any required control PVs"""
+        protos = self.config.get("protocol", ["ca", "pva"])
+
+        # Create a snapshot PV and a reset PV. These are used to trigger a snapshot of remote PVs, and to reset the model.
         snapshot_pvname = f"{self.config['prefix']}SNAPSHOT"
         self.snapshot_control_pv = snapshot_pvname
-        if snapshot_pvname in self.providers:
-            raise RuntimeError(
-                f"Fatal name conflict: {snapshot_pvname} for the snapshot PV already exists!"
-            )
-
-        self.providers[snapshot_pvname] = SharedPV(initial=NTScalar("d").wrap(0))
-
-        @self.providers[snapshot_pvname].put
-        def onPut(pv, op):
-            self.take_snapshot()
-            op.done()
 
         reset_pvname = f"{self.config['prefix']}RESET"
         self.reset_control_pv = reset_pvname
-        if reset_pvname in self.providers:
-            raise RuntimeError(
-                f"Fatal name conflict: {reset_pvname} for the reset PV already exists!"
-            )
 
-        self.providers[reset_pvname] = SharedPV(initial=NTScalar("i").wrap(0))
+        # Create PVA shared PVs for snapshot and reset if PVA is enabled
+        if "pva" in protos:
+            if snapshot_pvname in self.providers:
+                raise RuntimeError(
+                    f"Fatal name conflict: {snapshot_pvname} for the snapshot PV already exists!"
+                )
 
-        @self.providers[reset_pvname].put
-        def onResetPut(pv, op):
-            self._enqueue(
-                {},
-                reset=True,
-            )
-            op.done()
+            self.providers[snapshot_pvname] = SharedPV(initial=NTScalar("d").wrap(0))
 
-        if "ca" in self.config.get("protocol", ["ca", "pva"]):
+            @self.providers[snapshot_pvname].put
+            def onPut(pv, op):
+                self.take_snapshot()
+                op.done()
+
+            if reset_pvname in self.providers:
+                raise RuntimeError(
+                    f"Fatal name conflict: {reset_pvname} for the reset PV already exists!"
+                )
+
+            self.providers[reset_pvname] = SharedPV(initial=NTScalar("i").wrap(0))
+
+            @self.providers[reset_pvname].put
+            def onResetPut(pv, op):
+                self._enqueue(
+                    {},
+                    reset=True,
+                )
+                op.done()
+
+        # Create CA PVs for snapshot and reset if CA is enabled
+        if "ca" in protos:
             if snapshot_pvname in self.pvdb:
                 raise RuntimeError(
                     f"Fatal name conflict: {snapshot_pvname} for the CA snapshot PV already exists!"

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -125,6 +125,18 @@ class Runner:
             self.runner = runner
 
         def write(self, reason, value) -> bool:
+            if reason == self.runner.snapshot_control_pv:
+                self.runner.take_snapshot()
+                self.setParam(reason, value)
+                self.callbackPV(reason)
+                return True
+
+            if reason == self.runner.reset_control_pv:
+                self.runner._enqueue({}, reset=True)
+                self.setParam(reason, value)
+                self.callbackPV(reason)
+                return True
+
             # Lookup variable based on name
             vn = self.runner.pv_to_var.get(reason, None)
             if vn is None:
@@ -195,6 +207,8 @@ class Runner:
         self.pv_to_var: dict[str, str] = {}  # Map pv name -> variable name
         self.var_to_pv = {}
         self.ca_pvs = {}
+        self.snapshot_control_pv = ""
+        self.reset_control_pv = ""
         self.pvua_context = pvua.Context()
         self.ca_server: pcaspy.SimpleServer | None = None
         self.ca_driver: Runner.CaDriver | None = None
@@ -358,7 +372,10 @@ class Runner:
         return config
 
     def _enqueue(
-        self, values: dict[str, Any], done: Callable[[str | None], None] | None = None
+        self,
+        values: dict[str, Any],
+        done: Callable[[str | None], None] | None = None,
+        reset: bool = False,
     ) -> None:
         """
         Enqueue a batch of PV updates to be applied to the model.
@@ -372,8 +389,16 @@ class Runner:
             consumes these values has finished (or failed). Receives an error
             string on failure, or None on success. Used to defer signalling
             put-completion to clients until results are actually available.
+        reset : bool
+            When true, request model.reset() before applying this batch.
         """
-        self.queue.put({"values": values, "done": [done] if done is not None else []})
+        self.queue.put(
+            {
+                "values": values,
+                "done": [done] if done is not None else [],
+                "reset": reset,
+            }
+        )
 
     def _add_pv(
         self, pv: str, var: Variable, ro: bool, prefix: str, handler: VariableHandler
@@ -476,16 +501,57 @@ class Runner:
 
     def _create_control_pvs(self):
         """Create any required control PVs"""
-        pvname = f"{self.config['prefix']}SNAPSHOT"
-        if pvname in self.providers:
-            raise RuntimeError(f"Fatal name conflict: {pvname} for the snapshot PV already exists!")
+        snapshot_pvname = f"{self.config['prefix']}SNAPSHOT"
+        self.snapshot_control_pv = snapshot_pvname
+        if snapshot_pvname in self.providers:
+            raise RuntimeError(
+                f"Fatal name conflict: {snapshot_pvname} for the snapshot PV already exists!"
+            )
 
-        self.providers[pvname] = SharedPV(initial=NTScalar("d").wrap(0))
+        self.providers[snapshot_pvname] = SharedPV(initial=NTScalar("d").wrap(0))
 
-        @self.providers[pvname].put
+        @self.providers[snapshot_pvname].put
         def onPut(pv, op):
             self.take_snapshot()
             op.done()
+
+        reset_pvname = f"{self.config['prefix']}RESET"
+        self.reset_control_pv = reset_pvname
+        if reset_pvname in self.providers:
+            raise RuntimeError(
+                f"Fatal name conflict: {reset_pvname} for the reset PV already exists!"
+            )
+
+        self.providers[reset_pvname] = SharedPV(initial=NTScalar("i").wrap(0))
+
+        @self.providers[reset_pvname].put
+        def onResetPut(pv, op):
+            self._enqueue(
+                {},
+                reset=True,
+            )
+            op.done()
+
+        if "ca" in self.config.get("protocol", ["ca", "pva"]):
+            if snapshot_pvname in self.pvdb:
+                raise RuntimeError(
+                    f"Fatal name conflict: {snapshot_pvname} for the CA snapshot PV already exists!"
+                )
+            if reset_pvname in self.pvdb:
+                raise RuntimeError(
+                    f"Fatal name conflict: {reset_pvname} for the CA reset PV already exists!"
+                )
+
+            self.pvdb[snapshot_pvname] = {
+                "type": "int",
+                "value": 0,
+                "asyn": False,
+            }
+            self.pvdb[reset_pvname] = {
+                "type": "int",
+                "value": 0,
+                "asyn": False,
+            }
 
         return None
 
@@ -545,6 +611,7 @@ class Runner:
 
             value_data: dict = item["values"]
             done_callbacks: list = item["done"]
+            reset_requested: bool = item.get("reset", False)
 
             # Wait for a time window of 'update_rate' seconds to pass before continuing
             until = time.monotonic() + self.update_rate
@@ -553,6 +620,7 @@ class Runner:
                     next_update = self.queue.get_nowait()
                     value_data.update(next_update["values"])
                     done_callbacks.extend(next_update["done"])
+                    reset_requested = reset_requested or next_update.get("reset", False)
                 except Empty:
                     pass
 
@@ -587,6 +655,14 @@ class Runner:
             # Set and simulate
             sim_error = None
             try:
+                if reset_requested:
+                    reset_start = time.perf_counter()
+                    LOG.info("Reset requested through RESET control PV")
+                    self.model.reset()
+                    LOG.debug(
+                        f"Model reset() took {(time.perf_counter() - reset_start) * 1000.0:.3f} ms"
+                    )
+
                 set_start = time.perf_counter()
                 LOG.debug(f"Setting model with new values: {new_values}")
                 self.model.set(new_values)

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -735,7 +735,7 @@ class Runner:
 
     def _reset_to_cached_state(self) -> None:
         """Apply cached values to the model"""
-        LOG.info(f"Resetting model with new values: {self._cached_state}")
+        LOG.debug(f"Resetting model with new values: {self._cached_state}")
         self.model.set(self._cached_state)
 
     def _set_cached_state(self, state: dict[str, Any]) -> None:

--- a/lume_pva/tests/test_runner.py
+++ b/lume_pva/tests/test_runner.py
@@ -79,3 +79,44 @@ def test_no_variables() -> None:
     config = Runner.generate_config(empty_model)
 
     assert config["variables"] == {}
+
+
+def _make_runner_control_stub(protocol: list[str]) -> Runner:
+    runner = Runner.__new__(Runner)
+    runner._config = {
+        "prefix": "",
+        "protocol": protocol,
+    }
+    runner.providers = {}
+    runner.pvdb = {}
+    runner.snapshot_control_pv = ""
+    runner.reset_control_pv = ""
+
+    # _create_control_pvs wires callbacks to these methods; simple stubs are enough.
+    runner.take_snapshot = lambda: None
+    runner._enqueue = lambda *args, **kwargs: None
+    return runner
+
+
+def test_control_pvs_do_not_create_pva_sharedpvs_for_ca_only() -> None:
+    runner = _make_runner_control_stub(["ca"])
+
+    runner._create_control_pvs()
+
+    assert runner.snapshot_control_pv == "SNAPSHOT"
+    assert runner.reset_control_pv == "RESET"
+    assert "SNAPSHOT" not in runner.providers
+    assert "RESET" not in runner.providers
+    assert runner.pvdb["SNAPSHOT"]["type"] == "int"
+    assert runner.pvdb["RESET"]["type"] == "int"
+
+
+def test_control_pvs_create_pva_sharedpvs_when_pva_enabled() -> None:
+    runner = _make_runner_control_stub(["pva"])
+
+    runner._create_control_pvs()
+
+    assert "SNAPSHOT" in runner.providers
+    assert "RESET" in runner.providers
+    assert "SNAPSHOT" not in runner.pvdb
+    assert "RESET" not in runner.pvdb

--- a/lume_pva/tests/test_runner_epics.py
+++ b/lume_pva/tests/test_runner_epics.py
@@ -313,3 +313,21 @@ def test_failed_sim(harness: RunnerHandle):
     assert harness.completed.is_set()
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)
+
+
+def test_pva_reset_calls_model_reset(harness: RunnerHandle) -> None:
+    # Keep the model gate open so regular put/get traffic can flow freely.
+    harness.release.set()
+
+    with Context("pva") as ctx:
+        ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True)
+        assert float(ctx.get("input_a", timeout=OP_TIMEOUT)) == pytest.approx(5.0)
+        assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
+
+        # Any write to RESET must invoke model.reset() and publish the reset state.
+        harness.completed.clear()
+        ctx.put("RESET", 0, timeout=OP_TIMEOUT, wait=True)
+        assert harness.completed.wait(timeout=OP_TIMEOUT)
+
+        assert float(ctx.get("input_a", timeout=OP_TIMEOUT)) == pytest.approx(0.0)
+        assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(0.0)


### PR DESCRIPTION
This pull request adds a new RESET control PV to the `Runner`, allowing clients to reset the model state remotely via both PVA and CA protocols. It also refactors the control PV implementation to support this new feature and updates the documentation and tests accordingly.

**Control PV enhancements:**

* Added a `{prefix}RESET` control PV that, when written to, calls `model.reset()` and publishes the reset state to output PVs. This PV is served over PVA and, if configured, also over CA. [[1]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4L479-R555) [[2]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R128-R139)
* Refactored the control PV creation logic to set up both `{prefix}SNAPSHOT` and `{prefix}RESET` PVs, including name conflict checks and protocol-specific registration.

**Runner logic updates:**

* Modified the internal queue and processing logic to support reset requests by adding a `reset` flag to the queue items and handling it in the main runner loop. [[1]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R392-R401) [[2]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R614) [[3]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R623) [[4]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R658-R665) [[5]](diffhunk://#diff-338d3c80b431a67cc30f2759b7261660a8e2341a2eab98b696e83598546540f4R210-R211)

**Documentation and testing:**

* Updated the `README.md` to document the new RESET control PV and its behavior.
* Added a test to verify that writing to the RESET PV resets the model state as expected.