### PR TITLE
FIX: reject invalid inputs up-front to avoid PUT timeouts

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,15 @@
+import argparse
+
+from lume_pva.runner import PutMode
+
+
+def add_common_test_args(parser: argparse.ArgumentParser):
+    parser.add_argument("-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "--put-mode",
+        dest="put_mode",
+        type=str,
+        choices=list(PutMode.__members__.values()),
+        default=PutMode.Immediate.value,
+        help="Put mode to use. 'immediate' acks put requests immediately and 'complete' acks them only after the model has finished simulating.",
+    )

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -13,3 +13,10 @@ def add_common_test_args(parser: argparse.ArgumentParser):
         default=PutMode.Immediate.value,
         help="Put mode to use. 'immediate' acks put requests immediately and 'complete' acks them only after the model has finished simulating.",
     )
+    parser.add_argument(
+        "--pv-prefix",
+        dest="pv_prefix",
+        default="example:",
+        type=str,
+        help="Add this prefix to all PVs added by the model",
+    )

--- a/examples/fft_model.py
+++ b/examples/fft_model.py
@@ -185,16 +185,19 @@ if __name__ == "__main__":
                 "rate": 0.1,
                 "nvalues": 1024,
             },
-        }
+        },
+        prefix=args.pv_prefix,
     )
 
     model = FFTModel()
-    config = Runner.generate_config(model, put_mode=args.put_mode)
+    config = Runner.generate_config(model, put_mode=args.put_mode, prefix=args.pv_prefix)
 
     config["remote_model_mode"] = "continuous"
 
     for k in ["signal_a", "signal_b", "signal_c"]:
-        config["variables"][k]["mode"] = "remote"
+        v = config["variables"][k]
+        v["mode"] = "remote"
+        v["pv"] = f"{args.pv_prefix}{v['pv']}"  # Remap name with prefix
 
     runner = Runner(model=model, config=config)
     runner.run()

--- a/examples/fft_model.py
+++ b/examples/fft_model.py
@@ -7,6 +7,8 @@ from lume.variables import NDVariable, ScalarVariable
 from lume_pva.runner import Runner
 from lume_pva.simulator import SimpleSimulator
 
+from . import add_common_test_args
+
 
 class FFTModel(LUMEModel):
     """
@@ -152,7 +154,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-v", action="store_true", help="Enable verbose logging")
+    add_common_test_args(parser)
     args = parser.parse_args()
 
     # Configure logging for debug if requested
@@ -187,7 +189,7 @@ if __name__ == "__main__":
     )
 
     model = FFTModel()
-    config = Runner.generate_config(model)
+    config = Runner.generate_config(model, put_mode=args.put_mode)
 
     config["remote_model_mode"] = "continuous"
 

--- a/examples/math_model.py
+++ b/examples/math_model.py
@@ -13,6 +13,8 @@ from lume.variables import (
 from lume_pva.runner import Runner
 from lume_pva.simulator import SimpleSimulator
 
+from . import add_common_test_args
+
 
 class SimpleMathModel(LUMEModel):
     """
@@ -149,7 +151,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-v", action="store_true", help="Enable verbose logging")
+    add_common_test_args(parser)
     parser.add_argument(
         "--mode",
         type=str,
@@ -191,7 +193,7 @@ if __name__ == "__main__":
         )
 
     model = SimpleMathModel()
-    config = Runner.generate_config(model)
+    config = Runner.generate_config(model, put_mode=args.put_mode)
 
     config["description"] = "Simple math model demonstrating a number of variable types"
 

--- a/examples/math_model.py
+++ b/examples/math_model.py
@@ -189,11 +189,12 @@ if __name__ == "__main__":
                     "rate": 0.09,
                 },
                 "input_d": {"type": "float", "mode": "expr", "expr": "10*t", "rate": 1},
-            }
+            },
+            prefix=args.pv_prefix,
         )
 
     model = SimpleMathModel()
-    config = Runner.generate_config(model, put_mode=args.put_mode)
+    config = Runner.generate_config(model, put_mode=args.put_mode, prefix=args.pv_prefix)
 
     config["description"] = "Simple math model demonstrating a number of variable types"
 
@@ -202,7 +203,9 @@ if __name__ == "__main__":
 
     if args.mode in ["remote", "snapshot"]:
         for k in ["input_a", "input_b", "input_c"]:
-            config["variables"][k]["mode"] = "remote"
+            v = config["variables"][k]
+            v["mode"] = "remote"
+            v["pv"] = f"{args.pv_prefix}{v['pv']}"  # Remap name with prefix
 
     runner = Runner(model=model, config=config)
     runner.run()

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -176,7 +176,7 @@ class Runner:
                 return True
 
             # Lookup variable based on name
-            vn = self.runner.pv_to_var.get(reason, None)
+            vn = self.runner._pv_to_variable(reason)
             if vn is None:
                 return False
 
@@ -292,18 +292,17 @@ class Runner:
             # Set default PV name if not provided
             if "pv" not in c:
                 c["pv"] = c["name"]
-            pv = c["pv"]
+
+            # Lookup variable based on name
+            var = self.model.supported_variables.get(c["name"])
 
             # Validate some other things first
-            if c["name"] not in self.model.supported_variables:
+            if var is None:
                 raise KeyError(f'Variable "{c["name"]}" not found in model variables')
             if "mode" in c and c["mode"] not in VALID_PV_MODES:
                 raise KeyError(
                     f'Variable "{c["name"]} has invalid mode "{c["mode"]}". Must be one of {VALID_PV_MODES}'
                 )
-
-            # Lookup variable based on name
-            var = self.model.supported_variables[c["name"]]
 
             # Determine a default mode, if there is none
             if "mode" not in c:
@@ -326,10 +325,18 @@ class Runner:
                 LOG.warning(f'Unsupported variable "{var.name}". Skipping.')
                 continue
 
+            # Remap the PV name. Prefix is applied only to standalone inputs and outputs, since clients are usually
+            # consuming remote data that doesn't need to be made unique.
+            if c["mode"] == "remote":
+                pv = c["pv"]
+            else:
+                pv = self.config.get("prefix", "") + c["pv"]
+
             # Cache handler and type for later
             self.pv_handlers[var.name] = handler
             self.types[var.name] = handler.create_type(var)
 
+            # Map pv -> var (and vice versa)
             self.pv_to_var[pv] = var.name
             self.var_to_pv[var.name] = pv
 
@@ -339,7 +346,6 @@ class Runner:
                     pv,
                     var,
                     ro=c["mode"] == "ro",
-                    prefix=self.config.get("prefix", ""),
                     handler=handler,
                 )
             else:
@@ -365,7 +371,7 @@ class Runner:
         # Start the CA server under the shared async context
         if len(self.pvdb.keys()) > 0:
             self.ca_server = pcaspy.SimpleServer()
-            self.ca_server.createPV(self.config.get("prefix", ""), self.pvdb)
+            self.ca_server.createPV("", self.pvdb)
             self.ca_driver = Runner.CaDriver(self)
 
             # Spin up a thread to run the pcaspy update loop
@@ -466,9 +472,7 @@ class Runner:
             }
         )
 
-    def _add_pv(
-        self, pv: str, var: Variable, ro: bool, prefix: str, handler: VariableHandler
-    ) -> None:
+    def _add_pv(self, pv: str, var: Variable, ro: bool, handler: VariableHandler) -> None:
         """
         Create a new PV for CA and/or PVA
 
@@ -486,7 +490,7 @@ class Runner:
             The variable handler for this variable type
         """
         if self.supports_pva:
-            LOG.debug(f"Creating PVA PV: pv={pv}")
+            LOG.debug(f"Creating PVA PV: {pv}")
             pvobj = SharedPV(
                 handler=Runner.Handler(
                     variable=var,
@@ -498,7 +502,7 @@ class Runner:
                 initial=self._generate_value(var.name, None),
             )
             self.pvs[var.name] = pvobj
-            self.providers[f"{prefix}{pv}"] = pvobj
+            self.providers[pv] = pvobj
 
         if self.supports_ca:
             # Generate a default value suitable for pcaspy
@@ -508,12 +512,12 @@ class Runner:
             if isinstance(default_value, list) and isinstance(default_value[0], str):
                 return
 
-            LOG.debug(f"Creating CA PV: pv={pv}")
+            LOG.debug(f"Creating CA PV: {pv}")
             spec = handler.ca_pvspec(var)
 
-            self.pvdb[f"{prefix}{pv}"] = spec
-            self.pvdb[f"{prefix}{pv}"].update({"asyn": True})
+            self.pvdb[pv] = spec
             # enable async for put-completion
+            self.pvdb[pv].update({"asyn": True})
             self.ca_pvs[var.name] = pv
 
     def _add_client(self, pv: str, var: Variable, monitor: bool) -> bool:
@@ -661,7 +665,7 @@ class Runner:
         LOG.debug(f"Snapshot taken for PVs: {self.snapshot_pvs}")
         new_values = {}
         for pv in self.snapshot_pvs:
-            new_values[self.pv_to_var[pv]] = {
+            new_values[self._pv_to_variable(pv)] = {
                 "value": self.pvua_context.get(pv),
                 "ts": time.time(),
             }
@@ -669,7 +673,7 @@ class Runner:
 
     def _monitor_callback(self, pvname, value, **kwargs):
         """Callback from p4p monitor updates"""
-        self._enqueue({self.pv_to_var[pvname]: {"value": value, "ts": time.time()}})
+        self._enqueue({self._pv_to_variable(pvname): {"value": value, "ts": time.time()}})
 
     def _generate_value(self, pv: str, value: Any | None, ts: float | None = None) -> Value:
         """
@@ -865,3 +869,11 @@ class Runner:
                 timestamp=pcaspy.cas.epicsTimeStamp.fromPosixTimeStamp(time.time()),
             )
             self.ca_driver.updatePV(self.status_control_pv)
+
+    def _variable_to_pv(self, name: str) -> str | None:
+        """Returns the PV name for the specified variable name"""
+        return self.var_to_pv.get(name)
+
+    def _pv_to_variable(self, pv: str) -> str | None:
+        """Returns the variable name associated with the PV"""
+        return self.pv_to_var.get(pv)

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from enum import Enum, IntEnum
 from queue import Empty, Queue
 from typing import Any, TypedDict
 
@@ -13,10 +14,10 @@ import pcaspy
 import pcaspy.cas
 import pvua
 from lume.model import LUMEModel, Variable
-from lume.variables import ParticleGroupVariable
+from lume.variables import ConfigEnum, ParticleGroupVariable
 from p4p import Type, Value
 from p4p.client.thread import Subscription
-from p4p.nt import NTScalar
+from p4p.nt import NTEnum, NTScalar
 from p4p.server import ServerOperation
 from p4p.server.thread import SharedPV
 
@@ -30,6 +31,16 @@ VALID_MODEL_MODES = ["continuous", "snapshot"]
 
 DEFAULT_MODEL_MODE = "continuous"
 DEFAULT_PV_MODE = "rw"
+
+
+class ModelState(IntEnum):
+    Idle = 0
+    Simulating = 1
+
+
+class PutMode(str, Enum):
+    Immediate = "immediate"
+    Complete = "complete"
 
 
 class RunnerVariable(TypedDict):
@@ -69,12 +80,17 @@ class RunnerConfig(TypedDict):
         List of model variables
     protocol : list[str]
         List of supported protocols
+    put_mode : PutMode
+        Determines the behavior of put requests.
+        'immediate' (PutMode.Immediate) will ACK the PUT request immediately after inserting into the queue.
+        'complete' (PutMode.Complete) will ACK the PUT request only after the model has finished simulating.
     """
 
     remote_model_mode: str
     prefix: str
     variables: dict[str, RunnerVariable]
     protocol: list[str]
+    put_mode: PutMode
 
 
 class Runner:
@@ -96,22 +112,44 @@ class Runner:
         model: LUMEModel
         variable: Variable
 
-        def __init__(self, variable: Variable, runner: "Runner", read_only: bool):
+        def __init__(
+            self,
+            variable: Variable,
+            handler: VariableHandler,
+            runner: "Runner",
+            read_only: bool,
+            put_mode: PutMode,
+        ):
             self.model = runner.model
             self.variable = variable
             self.runner = runner
             self.ro = read_only
+            self.handler = handler
+            self.put_mode = put_mode
 
         def put(self, pv: SharedPV, op: ServerOperation):
             if self.ro:
                 op.done(error="Read only PV")
             else:
+                # Validate values and reject bad values immediately
+                try:
+                    self.variable.validate_value(
+                        self.handler.unpack_value(self.variable, op.value()),
+                        config=ConfigEnum.ERROR,
+                    )
+                except Exception as e:
+                    LOG.warning(f"{self.variable.name}: Rejected invalid value: {e!s}")
+                    op.done(error=str(e))
+                    return
+
                 # Update PVs in simulator
                 self.runner._enqueue(
                     {self.variable.name: {"value": op.value(), "ts": time.time()}},
                     done=lambda error: op.done(error=error),
                 )
                 pv.post(op.value())
+                if self.put_mode == PutMode.Immediate:
+                    op.done()
                 LOG.debug(f"Setting PVA: {self.variable.name} -> {op.value()}")
 
         def rpc(self, op: ServerOperation):
@@ -166,10 +204,22 @@ class Runner:
                 self.setParam(reason, value)
                 self.callbackPV(reason)
 
+            # Validate values before updating the model
+            try:
+                var.validate_value(nv, ConfigEnum.ERROR)
+            except Exception as e:
+                # Doesn't seem to be a way to reject CA updates with an error message.
+                LOG.warning(f"{reason}: Rejected invalid value: {e!s}")
+                self.callbackPV(reason)
+                return False
+
             self.runner._enqueue(
                 {vn: {"value": nv, "ts": time.time()}},
                 done=lambda error: _complete_put(),
             )
+
+            if self.runner._put_mode() == PutMode.Immediate:
+                _complete_put()
             return True
 
     def __init__(
@@ -201,7 +251,7 @@ class Runner:
         self.types = {}
         self.subs = {}
         self.context = p4p.client.thread.Context()
-        self.providers = {}  # Just for renaming
+        self.providers: dict[str, SharedPV] = {}  # Just for renaming
         self.pvdb = {}  # For pcaspy
         self.snapshot_pvs = []
         self.pv_to_var: dict[str, str] = {}  # Map pv name -> variable name
@@ -337,6 +387,7 @@ class Runner:
         prefix: str = "",
         remote_inputs: bool = False,
         name_transformer: Callable[[Variable, str], str] | None = None,
+        put_mode: PutMode = PutMode.Immediate,
     ) -> RunnerConfig:
         """
         Generate a configuration for the specified model.
@@ -351,7 +402,11 @@ class Runner:
             When true, model inputs (values not marked as rw) are configured as monitors for remote variables
         name_transformer: Callable[[Variable, str], str] | None
             A callable that transforms a variable's name into a new PV name. by default it just maps variable.name -> pv_name
-
+        put_mode : PutMode
+            Determines the behavior of put requests.
+            'immediate' (PutMode.Immediate) will ACK the PUT request immediately after inserting into the queue.
+            'complete' (PutMode.Complete) will ACK the PUT request only after the model has finished simulating.
+            For PutComplete mode, client timeouts must be adjusted to account for model simulation time.
         Returns
         -------
         RunnerConfig :
@@ -363,6 +418,8 @@ class Runner:
             "remote_model_mode": "continuous",
             "prefix": prefix,
             "max_array_bytes": os.environ.get("EPICS_CA_MAX_ARRAY_BYTES", "80000000"),
+            "put_mode": put_mode,
+            "update_rate": 0.1,
             "variables": {},
         }
         for k, v in model.supported_variables.items():
@@ -431,7 +488,13 @@ class Runner:
         if self.supports_pva:
             LOG.debug(f"Creating PVA PV: pv={pv}")
             pvobj = SharedPV(
-                handler=Runner.Handler(variable=var, runner=self, read_only=ro),
+                handler=Runner.Handler(
+                    variable=var,
+                    runner=self,
+                    read_only=ro,
+                    handler=handler,
+                    put_mode=self._put_mode(),
+                ),
                 initial=self._generate_value(var.name, None),
             )
             self.pvs[var.name] = pvobj
@@ -536,24 +599,23 @@ class Runner:
         reset_pvname = f"{self.config['prefix']}RESET"
         self.reset_control_pv = reset_pvname
 
+        status_control_pvname = f"{self.config['prefix']}STATUS"
+        self.status_control_pv = status_control_pvname
+
+        def conflict_check(x):
+            if x in self.pvdb or x in self.providers:
+                raise RuntimeError(f"Fatal name conflict: {x} already exists in the PV database!")
+
+        [conflict_check(x) for x in [snapshot_pvname, reset_pvname, status_control_pvname]]
+
         # Create PVA shared PVs for snapshot and reset if PVA is enabled
         if self.supports_pva:
-            if snapshot_pvname in self.providers:
-                raise RuntimeError(
-                    f"Fatal name conflict: {snapshot_pvname} for the snapshot PV already exists!"
-                )
-
             self.providers[snapshot_pvname] = SharedPV(initial=NTScalar("d").wrap(0))
 
             @self.providers[snapshot_pvname].put
             def onPut(pv, op):
                 self.take_snapshot()
                 op.done()
-
-            if reset_pvname in self.providers:
-                raise RuntimeError(
-                    f"Fatal name conflict: {reset_pvname} for the reset PV already exists!"
-                )
 
             self.providers[reset_pvname] = SharedPV(initial=NTScalar("i").wrap(0))
 
@@ -565,17 +627,19 @@ class Runner:
                 )
                 op.done()
 
+            self.status_control_pva_enum = NTEnum()
+            self.providers[status_control_pvname] = SharedPV(
+                initial=self.status_control_pva_enum.wrap(
+                    0, timestamp=time.time(), choices=list(ModelState.__members__.keys())
+                )
+            )
+
+            @self.providers[status_control_pvname].put
+            def onStatusPut(pv, op):
+                op.done(error="Read-only PV")
+
         # Create CA PVs for snapshot and reset if CA is enabled
         if self.supports_ca:
-            if snapshot_pvname in self.pvdb:
-                raise RuntimeError(
-                    f"Fatal name conflict: {snapshot_pvname} for the CA snapshot PV already exists!"
-                )
-            if reset_pvname in self.pvdb:
-                raise RuntimeError(
-                    f"Fatal name conflict: {reset_pvname} for the CA reset PV already exists!"
-                )
-
             self.pvdb[snapshot_pvname] = {
                 "type": "int",
                 "value": 0,
@@ -586,6 +650,7 @@ class Runner:
                 "value": 0,
                 "asyn": False,
             }
+            self.pvdb[status_control_pvname] = {"type": "enum", "enums": ["Idle", "Simulating"]}
 
         return None
 
@@ -653,10 +718,13 @@ class Runner:
                 try:
                     next_update = self.queue.get_nowait()
                     value_data.update(next_update["values"])
-                    done_callbacks.extend(next_update["done"])
+                    if next_update.get("done") is not None:
+                        done_callbacks.extend(next_update["done"])
                     reset_requested = reset_requested or next_update.get("reset", False)
                 except Empty:
                     pass
+
+            self._set_model_state(ModelState.Simulating)
 
             new_values = {}
             latest_ts = 0.0
@@ -715,10 +783,7 @@ class Runner:
                     if k in self.subs:
                         continue
 
-                    # The model may return None for an output; there is nothing
-                    # meaningful to post, and passing it downstream would either
-                    # silently substitute the variable default (PVA path) or raise
-                    # in value_to_native (CA path). Skip and warn instead.
+                    # The model my return None for an output. Let's reject those variable updates.
                     if v is None:
                         LOG.warning(f"Model returned None for output '{k}'; skipping update")
                         continue
@@ -756,12 +821,13 @@ class Runner:
                 LOG.error(f"Simulation Cycle Failed: ({sim_error}), resetting to cached value")
                 self._reset_to_cached_state()
             finally:
-                # With simulation compoleted, signal put completion to any waitihng clients
-                for cb in done_callbacks:
+                # With simulation completed, signal put completion to any waiting clients.
+                for cb in done_callbacks if self._put_mode() == PutMode.Complete else []:
                     try:
                         cb(sim_error)
                     except Exception as excp:
                         LOG.error(f"Error signalling put-completion: {excp}")
+                self._set_model_state(ModelState.Idle)
 
     def run(self):
         """
@@ -784,3 +850,18 @@ class Runner:
         """Save `state` to the cache"""
         LOG.debug(f"Caching model state: {state}")
         self._cached_state = state
+
+    def _put_mode(self) -> PutMode:
+        return self.config.get("put_mode", PutMode.Immediate)
+
+    def _set_model_state(self, state: ModelState):
+        """Updates the model state and related PVs"""
+        if (pv := self.providers.get(self.status_control_pv)) is not None:
+            pv.post(self.status_control_pva_enum.wrap(state, timestamp=time.time()))
+        if self.status_control_pv in self.pvdb.keys():
+            self.ca_driver.setParam(
+                self.status_control_pv,
+                state,
+                timestamp=pcaspy.cas.epicsTimeStamp.fromPosixTimeStamp(time.time()),
+            )
+            self.ca_driver.updatePV(self.status_control_pv)

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -108,7 +108,7 @@ class Runner:
             else:
                 # Update PVs in simulator
                 self.runner._enqueue(
-                    {self.variable.name: {"value": op.value(), "ts": time.monotonic()}},
+                    {self.variable.name: {"value": op.value(), "ts": time.time()}},
                     done=lambda error: op.done(error=error),
                 )
                 pv.post(op.value())
@@ -167,7 +167,7 @@ class Runner:
                 self.callbackPV(reason)
 
             self.runner._enqueue(
-                {vn: {"value": nv, "ts": time.monotonic()}},
+                {vn: {"value": nv, "ts": time.time()}},
                 done=lambda error: _complete_put(),
             )
             return True
@@ -598,13 +598,13 @@ class Runner:
         for pv in self.snapshot_pvs:
             new_values[self.pv_to_var[pv]] = {
                 "value": self.pvua_context.get(pv),
-                "ts": time.monotonic(),
+                "ts": time.time(),
             }
         self._enqueue(new_values)
 
     def _monitor_callback(self, pvname, value, **kwargs):
         """Callback from p4p monitor updates"""
-        self._enqueue({self.pv_to_var[pvname]: {"value": value, "ts": time.monotonic()}})
+        self._enqueue({self.pv_to_var[pvname]: {"value": value, "ts": time.time()}})
 
     def _generate_value(self, pv: str, value: Any | None, ts: float | None = None) -> Value:
         """
@@ -625,7 +625,7 @@ class Runner:
         Helper to update timestamp on a value
         """
         if ts is None:
-            ts = time.monotonic()
+            ts = time.time()
         value["timeStamp"]["nanoseconds"] = math.fmod(ts, 1.0) * 1e9
         value["timeStamp"]["secondsPastEpoch"] = int(ts)
 
@@ -678,7 +678,7 @@ class Runner:
 
             # Use current time if we're missing a latest timestamp
             if latest_ts <= 0:
-                latest_ts = time.monotonic()
+                latest_ts = time.time()
 
             # Stash previous state
             settable_var_names = [

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -4,7 +4,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
-from enum import Enum, IntEnum
+from enum import IntEnum, StrEnum
 from queue import Empty, Queue
 from typing import Any, TypedDict
 
@@ -32,18 +32,18 @@ class ModelState(IntEnum):
     Simulating = 1
 
 
-class PutMode(str, Enum):
+class PutMode(StrEnum):
     Immediate = "immediate"
     Complete = "complete"
 
 
-class VariableMode(str, Enum):
+class VariableMode(StrEnum):
     RO = "ro"
     RW = "rw"
     Remote = "remote"
 
 
-class ModelMode(str, Enum):
+class ModelMode(StrEnum):
     Continuous = "continuous"
     Snapshot = "snapshot"
 

--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -26,12 +26,6 @@ from lume_pva.variables import VariableHandler, find_variable_handler
 LOG = logging.getLogger("LumePva")
 logging.getLogger("pcaspy").setLevel(logging.WARNING)
 
-VALID_PV_MODES = ["rw", "ro", "remote"]
-VALID_MODEL_MODES = ["continuous", "snapshot"]
-
-DEFAULT_MODEL_MODE = "continuous"
-DEFAULT_PV_MODE = "rw"
-
 
 class ModelState(IntEnum):
     Idle = 0
@@ -41,6 +35,21 @@ class ModelState(IntEnum):
 class PutMode(str, Enum):
     Immediate = "immediate"
     Complete = "complete"
+
+
+class VariableMode(str, Enum):
+    RO = "ro"
+    RW = "rw"
+    Remote = "remote"
+
+
+class ModelMode(str, Enum):
+    Continuous = "continuous"
+    Snapshot = "snapshot"
+
+
+DEFAULT_MODEL_MODE = ModelMode.Continuous
+DEFAULT_PV_MODE = VariableMode.RW
 
 
 class RunnerVariable(TypedDict):
@@ -176,7 +185,7 @@ class Runner:
                 return True
 
             # Lookup variable based on name
-            vn = self.runner._pv_to_variable(reason)
+            vn = self.runner.pv_to_var[reason]
             if vn is None:
                 return False
 
@@ -218,7 +227,7 @@ class Runner:
                 done=lambda error: _complete_put(),
             )
 
-            if self.runner._put_mode() == PutMode.Immediate:
+            if self.runner.put_mode == PutMode.Immediate:
                 _complete_put()
             return True
 
@@ -277,9 +286,9 @@ class Runner:
         self.supports_pva = "pva" in self.protos
 
         # Validate some configuration options
-        if config.get("remote_model_mode", DEFAULT_MODEL_MODE) not in VALID_MODEL_MODES:
+        if config.get("remote_model_mode", DEFAULT_MODEL_MODE) not in ModelMode:
             raise KeyError(
-                f"Model has invalid model mode {config['remote_model_mode']}. Must be one of {VALID_MODEL_MODES}"
+                f"Model has invalid model mode {config['remote_model_mode']}. Must be one of {', '.join([x.name for x in ModelMode])}"
             )
 
         self.update_rate = config.get("update_rate", 0.1)
@@ -299,17 +308,17 @@ class Runner:
             # Validate some other things first
             if var is None:
                 raise KeyError(f'Variable "{c["name"]}" not found in model variables')
-            if "mode" in c and c["mode"] not in VALID_PV_MODES:
+            if "mode" in c and c["mode"] not in VariableMode:
                 raise KeyError(
-                    f'Variable "{c["name"]} has invalid mode "{c["mode"]}". Must be one of {VALID_PV_MODES}'
+                    f'Variable "{c["name"]} has invalid mode "{c["mode"]}". Must be one of {", ".join([x.name for x in VariableMode])}'
                 )
 
             # Determine a default mode, if there is none
             if "mode" not in c:
-                c["mode"] = "ro" if var.read_only else "rw"
+                c["mode"] = VariableMode.RO if var.read_only else VariableMode.RW
 
             # Validate r/w setting
-            if c["mode"] == "rw" and var.read_only:
+            if c["mode"] == VariableMode.RW and var.read_only:
                 raise ValueError(
                     f"Variable {c['name']} was configured with read-write permissions, but the variable is read-only"
                 )
@@ -340,12 +349,12 @@ class Runner:
             self.pv_to_var[pv] = var.name
             self.var_to_pv[var.name] = pv
 
-            if c["mode"] in ["ro", "rw"]:
+            if c["mode"] in [VariableMode.RO, VariableMode.RW]:
                 # Generate a PV to be served
                 self._add_pv(
                     pv,
                     var,
-                    ro=c["mode"] == "ro",
+                    ro=c["mode"] == VariableMode.RO,
                     handler=handler,
                 )
             else:
@@ -354,7 +363,7 @@ class Runner:
                     pv,
                     var,
                     monitor=self.config["remote_model_mode"]
-                    == "continuous",  # Use monitor if in continuous mode
+                    == ModelMode.Continuous,  # Use monitor if in continuous mode
                 )
 
         # Create an informational PV (i.e. including list of variables, etc.)
@@ -421,7 +430,7 @@ class Runner:
         """
         config = {
             "description": "",
-            "remote_model_mode": "continuous",
+            "remote_model_mode": ModelMode.Continuous,
             "prefix": prefix,
             "max_array_bytes": os.environ.get("EPICS_CA_MAX_ARRAY_BYTES", "80000000"),
             "put_mode": put_mode,
@@ -429,9 +438,9 @@ class Runner:
             "variables": {},
         }
         for k, v in model.supported_variables.items():
-            mode = "ro" if v.read_only else "rw"
+            mode = VariableMode.RO if v.read_only else VariableMode.RW
             if remote_inputs and not v.read_only:
-                mode = "remote"
+                mode = VariableMode.Remote
             if name_transformer is not None:
                 pv = name_transformer(v, v.name)
             else:
@@ -497,7 +506,7 @@ class Runner:
                     runner=self,
                     read_only=ro,
                     handler=handler,
-                    put_mode=self._put_mode(),
+                    put_mode=self.put_mode,
                 ),
                 initial=self._generate_value(var.name, None),
             )
@@ -665,7 +674,7 @@ class Runner:
         LOG.debug(f"Snapshot taken for PVs: {self.snapshot_pvs}")
         new_values = {}
         for pv in self.snapshot_pvs:
-            new_values[self._pv_to_variable(pv)] = {
+            new_values[self.pv_to_var[pv]] = {
                 "value": self.pvua_context.get(pv),
                 "ts": time.time(),
             }
@@ -673,7 +682,7 @@ class Runner:
 
     def _monitor_callback(self, pvname, value, **kwargs):
         """Callback from p4p monitor updates"""
-        self._enqueue({self._pv_to_variable(pvname): {"value": value, "ts": time.time()}})
+        self._enqueue({self.pv_to_var[pvname]: {"value": value, "ts": time.time()}})
 
     def _generate_value(self, pv: str, value: Any | None, ts: float | None = None) -> Value:
         """
@@ -793,16 +802,14 @@ class Runner:
                         continue
 
                     # Update PVA component
-                    pv = self.pvs.get(k)
-                    if pv is not None:
+                    if (pv := self.pvs.get(k)) is not None:
                         try:
                             pv.post(self._generate_value(k, v, latest_ts))
                         except Exception as e:
                             LOG.error(f"Error posting value for {k}: {e}")
 
                     # Update CA component
-                    capv = self.ca_pvs.get(k)
-                    if capv is not None and self.ca_driver is not None:
+                    if (capv := self.ca_pvs.get(k)) is not None and self.ca_driver is not None:
                         # pcaspy can only understand native python types, not necessarily what the model gives us.
                         nv = self.pv_handlers[k].value_to_native(
                             self.model.supported_variables[k], v
@@ -826,7 +833,7 @@ class Runner:
                 self._reset_to_cached_state()
             finally:
                 # With simulation completed, signal put completion to any waiting clients.
-                for cb in done_callbacks if self._put_mode() == PutMode.Complete else []:
+                for cb in done_callbacks if self.put_mode == PutMode.Complete else []:
                     try:
                         cb(sim_error)
                     except Exception as excp:
@@ -855,7 +862,8 @@ class Runner:
         LOG.debug(f"Caching model state: {state}")
         self._cached_state = state
 
-    def _put_mode(self) -> PutMode:
+    @property
+    def put_mode(self) -> PutMode:
         return self.config.get("put_mode", PutMode.Immediate)
 
     def _set_model_state(self, state: ModelState):
@@ -869,11 +877,3 @@ class Runner:
                 timestamp=pcaspy.cas.epicsTimeStamp.fromPosixTimeStamp(time.time()),
             )
             self.ca_driver.updatePV(self.status_control_pv)
-
-    def _variable_to_pv(self, name: str) -> str | None:
-        """Returns the PV name for the specified variable name"""
-        return self.var_to_pv.get(name)
-
-    def _pv_to_variable(self, pv: str) -> str | None:
-        """Returns the variable name associated with the PV"""
-        return self.pv_to_var.get(pv)

--- a/lume_pva/simulator.py
+++ b/lume_pva/simulator.py
@@ -47,7 +47,7 @@ class SimpleSimulator:
         elif type in ["array1d"]:
             return NTNDArray()
 
-    def __init__(self, pvs: dict):
+    def __init__(self, pvs: dict, prefix: str = ""):
         """
         Initialize the simple PV simulator
 
@@ -66,9 +66,13 @@ class SimpleSimulator:
 
         """
         self.server = pcaspy.SimpleServer()
-        self.pvs = copy.deepcopy(pvs)
+        self.pvs = {}
         self.should_exit = False
         self.sleep_time = 0.001
+
+        # Build PV dict with prefix applied
+        for k, v in pvs.items():
+            self.pvs[prefix + k] = copy.deepcopy(pvs[k])
 
         # Build list of globals for eval() calls
         self.math_globals = {"t": 0}

--- a/lume_pva/tests/test_runner_epics.py
+++ b/lume_pva/tests/test_runner_epics.py
@@ -28,6 +28,7 @@ fresh Runner.
 import multiprocessing
 import os
 import threading
+import time
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event as mpEvent
@@ -227,6 +228,19 @@ def clear_harness(harness: RunnerHandle) -> None:
     harness.release.clear()
 
 
+def _wait_model_post(harness: RunnerHandle, timeout: float) -> bool:
+    """Waits for the model to finish simulating and post the results"""
+    if harness.put_mode == PutMode.Complete:
+        return True
+    assert harness.completed.wait(timeout)
+    start = time.monotonic()
+    while time.monotonic() < (timeout + start):
+        if epics.caget("STATUS") == 0:
+            return True
+        time.sleep(0.1)
+    return False
+
+
 def _assert_put_mode(harness: RunnerHandle, putter: Callable[[], None]) -> None:
     """Run ``putter`` on a thread and assert it blocks until the sim completes.
 
@@ -279,6 +293,13 @@ def test_pva_put_waits_for_simulation(harness: RunnerHandle) -> None:
     with Context("pva") as ctx:
         _assert_put_mode(harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True))
 
+        if harness.put_mode == PutMode.Complete:
+            assert harness.completed.is_set()
+        elif harness.put_mode == PutMode.Immediate:
+            assert _wait_model_post(harness, OP_TIMEOUT)
+        else:
+            raise ValueError(f"Unknown put_mode {harness.put_mode}")
+
         assert harness.completed.is_set()
         assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
 
@@ -290,15 +311,50 @@ def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
         harness, lambda: epics.caput("input_a", 7.0, wait=True, timeout=10 * OP_TIMEOUT)
     )
 
-    assert harness.completed.is_set()
+    if harness.put_mode == PutMode.Complete:
+        assert harness.completed.is_set()
+    elif harness.put_mode == PutMode.Immediate:
+        assert _wait_model_post(harness, OP_TIMEOUT)
+    else:
+        raise ValueError(f"Unknown put_mode {harness.put_mode}")
+
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(14.0)
 
 
+def test_status_pv(harness: RunnerHandle):
+    """Tests the STATUS pv (indicating model state)"""
+    test_status_edges = 0
+    test_status_cv = 0
+
+    ev = threading.Event()
+
+    def _test_status_cb(pvname, value, **kw):
+        nonlocal test_status_edges, test_status_cv
+        if value in [0, 1] and value != test_status_cv:
+            test_status_edges += 1
+            test_status_cv = value
+            if test_status_edges == 2:
+                ev.set()
+
+    status_pv = epics.get_pv("STATUS")
+    assert status_pv.get() == 0
+    status_pv.add_callback(_test_status_cb, run_now=True)
+    assert status_pv.wait_for_connection(OP_TIMEOUT)
+
+    # Trigger processing
+    epics.caput("input_a", 2.0, wait=True)
+    assert _wait_model_post(harness, OP_TIMEOUT)
+
+    # Yet Another Sync Issue: Monitors may be updated after explicit get requests return, thus _wait_model_post does not guarantee
+    # that 'STATUS' has transitioned twice (according to our callback, at least). So we have to use an event to check success.
+    assert ev.wait(OP_TIMEOUT)
+
+
 def test_standard_sim(harness: RunnerHandle):
-    # attempt set out of bounds, no need to wait
+    # Attempt a normal set
     harness.completed.clear()
     epics.caput("input_a", 10.0)
-    assert harness.completed.wait(timeout=OP_TIMEOUT)
+    assert _wait_model_post(harness, OP_TIMEOUT)
 
     # assert model set has completed
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(20.0)
@@ -313,14 +369,16 @@ def test_failed_sim(harness: RunnerHandle):
     # Reasonable input
     harness.completed.clear()
     epics.caput("input_a", 4.2, wait=True)
-    assert harness.completed.wait(timeout=OP_TIMEOUT)
+    assert _wait_model_post(harness, OP_TIMEOUT)
 
     # Verify record has processed
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)
 
-    # attempt set out of bounds
+    # attempt set out of bounds - the model should NOT simulate here
+    harness.entered.clear()
     epics.caput("input_a", 7.0e6, wait=True)
+    assert not harness.entered.wait(timeout=0.5)
 
     # reverting to previous (cached) value, runner is still operational
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
@@ -334,7 +392,7 @@ def test_pva_reset_calls_model_reset(harness: RunnerHandle) -> None:
     with Context("pva") as ctx:
         harness.completed.clear()
         ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True)
-        assert harness.completed.wait(timeout=OP_TIMEOUT)
+        assert _wait_model_post(harness, OP_TIMEOUT)
 
         assert float(ctx.get("input_a", timeout=OP_TIMEOUT)) == pytest.approx(5.0)
         assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)

--- a/lume_pva/tests/test_runner_epics.py
+++ b/lume_pva/tests/test_runner_epics.py
@@ -37,6 +37,8 @@ import pytest
 from lume.exceptions import ReadOnlyError
 from lume.variables.variable import ConfigEnum, Variable
 
+from lume_pva.runner import PutMode
+
 # Keep all EPICS traffic on the loopback interface. Must be set before p4p,
 # pyepics, or the pcaspy server (created in Runner.__init__) initialise.
 os.environ.setdefault("EPICS_CA_ADDR_LIST", "127.0.0.1")
@@ -138,14 +140,16 @@ class GatedModel(LUMEModel):
         self._state = {"input_a": 0.0, "sum_output": 0.0}
 
 
-def _serve(release: mpEvent, entered: mpEvent, completed: mpEvent, ready: mpEvent) -> None:
+def _serve(
+    put_mode: PutMode, release: mpEvent, entered: mpEvent, completed: mpEvent, ready: mpEvent
+) -> None:
     """Child-process entry point: serve a gated model over CA and PVA.
 
     Must be importable at module top level so the ``spawn`` start method can
     locate it. Blocks forever once ready; the parent terminates the process.
     """
     model = GatedModel(release, entered, completed)
-    config = Runner.generate_config(model)
+    config = Runner.generate_config(model, put_mode=put_mode)
     # No batching delay -- the cycle is driven purely by the gate.
     config["update_rate"] = 0.0
 
@@ -172,10 +176,11 @@ class RunnerHandle:
     release: mpEvent
     entered: mpEvent
     completed: mpEvent
+    put_mode: PutMode
 
 
-@pytest.fixture(scope="function")
-def harness() -> Generator[RunnerHandle, None, None]:
+@pytest.fixture(scope="function", params=[PutMode.Complete, PutMode.Immediate])
+def harness(request) -> Generator[RunnerHandle, None, None]:
     """
     Run a Runner in a child process and yield the shared gate + a PVA client.
 
@@ -192,7 +197,7 @@ def harness() -> Generator[RunnerHandle, None, None]:
 
     proc = _MP.Process(
         target=_serve,
-        args=(release, entered, completed, ready),
+        args=(request.param, release, entered, completed, ready),
         daemon=True,
     )
     proc.start()
@@ -202,6 +207,7 @@ def harness() -> Generator[RunnerHandle, None, None]:
         release=release,
         entered=entered,
         completed=completed,
+        put_mode=request.param,
     )
     try:
         yield handle
@@ -221,7 +227,7 @@ def clear_harness(harness: RunnerHandle) -> None:
     harness.release.clear()
 
 
-def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) -> None:
+def _assert_put_mode(harness: RunnerHandle, putter: Callable[[], None]) -> None:
     """Run ``putter`` on a thread and assert it blocks until the sim completes.
 
     ``putter`` must perform a blocking, completion-aware put (PVA put, or
@@ -246,12 +252,20 @@ def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) ->
     # The value reached the runner and the simulation is now running...
     assert harness.entered.wait(timeout=OP_TIMEOUT), "simulation never started"
 
-    # ...so a completion-aware put must still be blocked. If this fires, the
-    # client was signalled before the simulation finished (put-completion bug).
-    assert not put_returned.wait(
-        timeout=BLOCK_WINDOW
-    ), "put reported completion before the simulation finished"
-    assert thread.is_alive()
+    if harness.put_mode == PutMode.Complete:
+        # ...so a completion-aware put must still be blocked. If this fires, the
+        # client was signalled before the simulation finished (put-completion bug).
+        assert not put_returned.wait(
+            timeout=BLOCK_WINDOW
+        ), "put reported completion before the simulation finished"
+        assert thread.is_alive()
+    elif harness.put_mode == PutMode.Immediate:
+        # Ensure the put returned immediately for immediate mode
+        assert put_returned.wait(
+            timeout=OP_TIMEOUT
+        ), "put reported completion after the simulation finished"
+    else:
+        assert False, "Invalid put mode"
 
     # Let the simulation finish; the put must now complete.
     harness.release.set()
@@ -263,18 +277,16 @@ def _assert_put_completion(harness: RunnerHandle, putter: Callable[[], None]) ->
 
 def test_pva_put_waits_for_simulation(harness: RunnerHandle) -> None:
     with Context("pva") as ctx:
-        _assert_put_completion(
-            harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True)
-        )
+        _assert_put_mode(harness, lambda: ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True))
 
         assert harness.completed.is_set()
         assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
 
 
 def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
-    # caput timeout needs to essentially run forever, to `_assert_put_completion` to check
+    # caput timeout needs to essentially run forever, to `_assert_put_mode` to check
     # if the thread has completed.
-    _assert_put_completion(
+    _assert_put_mode(
         harness, lambda: epics.caput("input_a", 7.0, wait=True, timeout=10 * OP_TIMEOUT)
     )
 
@@ -284,25 +296,26 @@ def test_ca_put_waits_for_simulation(harness: RunnerHandle) -> None:
 
 def test_standard_sim(harness: RunnerHandle):
     # attempt set out of bounds, no need to wait
+    harness.completed.clear()
     epics.caput("input_a", 10.0)
+    assert harness.completed.wait(timeout=OP_TIMEOUT)
 
     # assert model set has completed
-    assert harness.completed.is_set()
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(20.0)
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
 
 
 def test_failed_sim(harness: RunnerHandle):
-    assert harness.completed.is_set()
     # Assert initial state
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(0.0)
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(0.0)
 
     # Reasonable input
+    harness.completed.clear()
     epics.caput("input_a", 4.2, wait=True)
+    assert harness.completed.wait(timeout=OP_TIMEOUT)
 
     # Verify record has processed
-    assert harness.completed.is_set()
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)
 
@@ -310,7 +323,6 @@ def test_failed_sim(harness: RunnerHandle):
     epics.caput("input_a", 7.0e6, wait=True)
 
     # reverting to previous (cached) value, runner is still operational
-    assert harness.completed.is_set()
     assert float(epics.caget("input_a", timeout=OP_TIMEOUT)) == pytest.approx(4.2)
     assert float(epics.caget("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(8.4)
 
@@ -320,7 +332,10 @@ def test_pva_reset_calls_model_reset(harness: RunnerHandle) -> None:
     harness.release.set()
 
     with Context("pva") as ctx:
+        harness.completed.clear()
         ctx.put("input_a", 5.0, timeout=OP_TIMEOUT, wait=True)
+        assert harness.completed.wait(timeout=OP_TIMEOUT)
+
         assert float(ctx.get("input_a", timeout=OP_TIMEOUT)) == pytest.approx(5.0)
         assert float(ctx.get("sum_output", timeout=OP_TIMEOUT)) == pytest.approx(10.0)
 


### PR DESCRIPTION
Models that take a while to simulate can delay the put `done` callbacks until they timeout. `caput` just shows a stale value in its readback, and `pvput` displays "Put timeout".

Even if we move the `done` callbacks to before the `Model.set` call, updates can get stalled in the queue and timeout. For example, if you have a slow model and `caput`/`pvput` while the model is simulating.

I'm not sure that there's a good way to implement `done` callbacks that encompass exceptions thrown during model simulation. The best thing we can do is reject invalid values up front in the CA/PVA callbacks. Luckily PVA allows us to specify an error message, though CA doesn't (hence the `LOG.warn`).

Curious if you have any better ideas or feedback on this change @tangkong. Do you guys need the caput-waits-for-model-simulation behavior?

Closes #39
Closes #43 