### PR TITLE
Fix simulator timestamping, add version+hostname to model_info

### DIFF
--- a/lume_pva/runner.py
+++ b/lume_pva/runner.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+import platform
 import threading
 import time
 from collections.abc import Callable
@@ -22,6 +23,11 @@ from p4p.server import ServerOperation
 from p4p.server.thread import SharedPV
 
 from lume_pva.variables import VariableHandler, find_variable_handler
+
+try:
+    from ._version import version as lume_pva_version
+except ImportError:
+    lume_pva_version = "HEAD"
 
 LOG = logging.getLogger("LumePva")
 logging.getLogger("pcaspy").setLevel(logging.WARNING)
@@ -559,6 +565,8 @@ class Runner:
             [
                 ("class", "s"),
                 ("description", "s"),
+                ("lume_pva_version", "s"),
+                ("hostname", "s"),
                 (
                     "env",
                     ("S", None, [(x, "s") for x in envs]),
@@ -583,6 +591,8 @@ class Runner:
         val = Value(self.types[pv])
         val["class"] = self.model.__class__.__name__
         val["description"] = self.config["description"]
+        val["lume_pva_version"] = lume_pva_version
+        val["hostname"] = platform.node()
 
         for e in envs:
             val["env"][e] = os.environ.get(e, "")

--- a/lume_pva/simulator.py
+++ b/lume_pva/simulator.py
@@ -176,8 +176,8 @@ class SimpleSimulator:
 
             # Update the value if we have a new one
             if nv is not None:
-                self.providers[k].post(nv, timestamp=time.monotonic())
-                self.driver.setParam(k, nv, timestamp=time.monotonic())
+                self.providers[k].post(nv, timestamp=time.time())
+                self.driver.setParam(k, nv, timestamp=time.time())
                 self.driver.updatePV(k)
 
     def wait(self):


### PR DESCRIPTION
What it says on the tin. Fix timestamping in the simulator (only needed for example code), add hostname+lume pva version to the model_info pv